### PR TITLE
fix close method's signature

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@types/node": "^10.11.4",
-    "@types/websocket": "0.0.40"
+    "@types/websocket": "^1.0.10"
   },
   "homepage": "https://github.com/samchon/websocket-polyfill#readme",
   "repository": {

--- a/src/WebSocket.ts
+++ b/src/WebSocket.ts
@@ -1,7 +1,7 @@
 import { 
 	client as Client, 
 	connection as Connection,
-	IMessage
+  Message
 } from "websocket";
 
 import { EventTarget } from "./events/EventTarget";
@@ -32,6 +32,17 @@ export class WebSocket extends EventTarget<WebSocketEventMap>
 	 */
 	private state_: number;
 
+	/**
+	 * @hidden
+	 */
+	private url_: string;
+	
+	/**
+	 * @hidden
+	 */
+	private protocol_: string;
+	
+
 	/* ----------------------------------------------------------------
 		CONSTRUCTORS
 	---------------------------------------------------------------- */
@@ -52,6 +63,9 @@ export class WebSocket extends EventTarget<WebSocketEventMap>
 
 		if (typeof protocols === "string")
 			protocols = [protocols];
+
+		this.url_ = url;
+		this.protocol_ = protocols[0];
 
 		// DO CONNECT
 		this.client_.connect(
@@ -102,14 +116,12 @@ export class WebSocket extends EventTarget<WebSocketEventMap>
 	---------------------------------------------------------------- */
 	public get url(): string
 	{
-		return this.client_.url.href;
+		return this.url_
 	}
 
 	public get protocol(): string
 	{
-		return this.client_.protocols
-			? this.client_.protocols[0]
-			: "";
+		return this.protocol_
 	}
 
 	public get extensions(): string
@@ -222,12 +234,12 @@ export class WebSocket extends EventTarget<WebSocketEventMap>
 	/**
 	 * @hidden
 	 */
-	private _Handle_message(message: IMessage): void
+	private _Handle_message(message: Message): void
 	{
 		let event: MessageEvent = new MessageEvent("message",
 		{
 			...EVENT_INIT,
-			data: message.binaryData 
+			data: message.type === 'binary'
 				? message.binaryData 
 				: message.utf8Data
 		})

--- a/src/WebSocket.ts
+++ b/src/WebSocket.ts
@@ -77,10 +77,7 @@ export class WebSocket extends EventTarget<WebSocketEventMap>
 	public close(code?: number, reason?: string): void
 	{
 		this.state_ = WebSocket.CLOSING;
-		if (code === undefined)
-			this.connection_.sendCloseFrame();
-		else
-			this.connection_.sendCloseFrame(code, reason, true);
+		this.connection_.sendCloseFrame(code, reason);
 	}
 
 	/* ================================================================

--- a/src/WebSocket.ts
+++ b/src/WebSocket.ts
@@ -181,7 +181,7 @@ export class WebSocket extends EventTarget<WebSocketEventMap>
 			this.removeEventListener(type, <any>this.on_[type]);
 		
 		this.addEventListener(type, <any>listener);
-		this.on_[type] = listener;
+		this.on_[type] = <any>listener;
 	}
 
 	/* ----------------------------------------------------------------


### PR DESCRIPTION
The 3rd argument of the `sendCloseFrame()` method is no longer a "force" flag, but an optional callback, customary in Node.js. (See WebsocketConnections.js L731 in https://github.com/theturtle32/WebSocket-Node/commit/f3f39e6a98185318498fe086a07c515235388b76 and WebsocketConnections.js L727 in https://github.com/theturtle32/WebSocket-Node/commit/5f0c4901ac646c50d89db6a728540204eec8593c)

The indirect cause of producing this bug was that it kept referring to the old type definition file, so this PR will fix that.