### PR TITLE
fix package license typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "licenses": [
     {
-      "type": "BSD 3-Clause",
+      "type": "BSD-3-Clause",
       "url": "https://opensource.org/licenses/BSD-3-Clause"
     }
   ],


### PR DESCRIPTION
Even if deprecated it's still used as a dependency in some other packages and the license checker (https://github.com/davglass/license-checker) found the typo for `BSD 3-Clause`, it should be `BSD-3-Clause`.
Although, the fix is easy, and we can just add `BSD 3-Clause` to the acceptable lists it's better to fix at source.